### PR TITLE
Optimization of camera mode change for better E-M10 MKIV support

### DIFF
--- a/src/olympuswifi/camera.py
+++ b/src/olympuswifi/camera.py
@@ -577,6 +577,7 @@ class OlympusCamera:
         if self._camera_status.liveview_active:
             if self._action_begin(self.CamMode.RECORD):
                 self.send_command('exec_takemisc', com='stopliveview')
+                self._switch_cammode(self.CamMode.PLAY)
                 self._camera_status.liveview_active = False
                 self._camera_status.liveview_restart = False
                 self._action_end()

--- a/src/olympuswifi/camera.py
+++ b/src/olympuswifi/camera.py
@@ -557,7 +557,8 @@ class OlympusCamera:
         :type lvqty: *str*
         :returns: list of funcid names that will be in the RTP extension.
         """
-        if self._action_begin(cammode=self.CamMode.RECORD, force=True, lvqty=lvqty):
+        if self._action_begin(self.CamMode.PLAY):
+            self._switch_cammode(cammode=self.CamMode.RECORD, lvqty=lvqty)
             self._camera_status.liveview_lvqty = lvqty
             self._camera_status.liveview_port = port
             xml = self.send_command('exec_takemisc', com='startliveview',

--- a/src/olympuswifi/liveview.py
+++ b/src/olympuswifi/liveview.py
@@ -323,10 +323,7 @@ class LiveViewWindow:
 
     def take_pic(self) -> None:
         "Take a picture."
-        self.camera.stop_liveview()
         self.camera.take_picture()
-        self.camera.start_liveview(port=self.port,
-                                   lvqty=self.lvqty_list[self.lvqty_cur])
 
     def on_lvqty(self, *args) -> None:
         """
@@ -337,7 +334,6 @@ class LiveViewWindow:
         if self.lvqty_cur != self.lvqty_var.get():
             self.lvqty_cur = self.lvqty_var.get()
             self.camera.stop_liveview()
-            self.camera.send_command('switch_cammode', mode='play')
             self.camera.start_liveview(port=self.port,
                                        lvqty=self.lvqty_list[self.lvqty_cur])
 
@@ -352,11 +348,8 @@ class LiveViewWindow:
         camprop = self.camprop_info[var_name]
         if camprop.cur_val != camprop.variable.get():
             camprop.cur_val = camprop.variable.get()
-            self.camera.stop_liveview()
             self.camera.set_camprop(camprop.name,
                                     camprop.values[camprop.cur_val])
-            self.camera.start_liveview(port=self.port,
-                                  lvqty=self.lvqty_list[self.lvqty_cur])
 
     def next_image(self) -> ImageTk.PhotoImage:
         """
@@ -432,10 +425,7 @@ class LiveViewWindow:
         The live view is stopped before setting the clock and restarted
         afterwards.
         """
-        self.camera.stop_liveview()
         self.camera.set_clock()
-        self.camera.start_liveview(port=self.port,
-                                   lvqty=self.lvqty_list[self.lvqty_cur])
 
     def power_off_and_exit(self):
         "Turn camera off and exit."

--- a/src/olympuswifi/liveview.py
+++ b/src/olympuswifi/liveview.py
@@ -1,4 +1,4 @@
-import argparse, datetime, io, os, queue, socket, sys, threading, tkinter, time
+import argparse, io, queue, socket, threading, tkinter
 from dataclasses import dataclass   # needs Python 3.7 or later
 from typing import Tuple, Optional
 
@@ -364,7 +364,13 @@ class LiveViewWindow:
 
         :returns: *ImageTk.PhotoImage*
         """
-        jpeg_and_extension = self.img_queue.get()
+        try:
+            jpeg_and_extension = self.img_queue.get(timeout=4.0)
+        except queue.Empty as e:
+            e.add_note("No data could be fetched within 4s.")
+            raise TimeoutError("Timeout while waiting for imagedata from camera. Maybe you need to check your "
+                               "firewall settings for incoming UDP traffic (from 192.168.0.10).") from e
+
         orientation = self.get_orientation(jpeg_and_extension.extension)
         if orientation is None or orientation == 1:
             return ImageTk.PhotoImage(data=jpeg_and_extension.jpeg)


### PR DESCRIPTION
The current code does some unmanaged switching between different camera modes. This has some drawbacks especially for the E-M10 MKIV which doesn't have a "SHUTTER" mode. In order to take a picture with the E-M10 MKIV you have to stay in "RECORD" mode with live view enabled. Using the code provided by camdroid (https://github.com/joergmlpts/olympus-wifi/pull/3) it is possible to take pictures, but there are two restarts of the liveview involved. Further you have to know that you need an instance of the M10MKIV class.

What I tried to archive with the code changes is to add an approach that allows the execution of one action at a time with a mode change only if it is required. For example: If you want to set the time while you are in the PLAY mode, the mode will not be changed. If you currently execute the live view in RECORD mode, the mode will be temporarily changed during the operation. Live view will be restarted automatically. 

Besides a faster operation, this allows the E-M10 MKIV to be efficiently used with the rest of the code. I added an extra path for taking pictures with the E-10 MKIV instead of the inherited class. If there are more differences with other new camera models it might be a good idea for the previous approach, but I think this should be used in combination with a factory of some kind. At this stage I think it doesn't need that kind of complexity.

I hope the code quality is sufficient as I am normally not using Python on a daily basis ;)

I tested the code using my E-M10 MKIV. I don't own any other model. It would be good if anyone is able to do some testing using an older model which supports the SHUTTER mode.

